### PR TITLE
Use pip in installation instructions, for better py35 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,9 +22,9 @@ Installation
 ============
 You do not need to install the examples, but you can install all the
 dependencies of **niflexlogger-examples** by downloading the project source and
-running::
+running this from the project directory::
 
-   $ python setup.py install
+   $ pip install .
 
 .. _usage_section:
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niflexlogger-examples-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Change installation instructions from "python setup.py install" to "pip install ."

### Why should this Pull Request be merged?

In python 3.5, "python setup.py install" does not find a suitable pypi file for the nisystemlink-clients dependency, unless you first upgrade setuptools.

### What testing has been done?

Tested `pip install .` in python 3.5 and 3.7
